### PR TITLE
Take data for /inne from cache server, and do not use raw brightness

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,14 +38,14 @@ tg.on('message', function(msg) {
     });
   } else if(!msg.text.indexOf('/inne')) {
     console.log('retrieving inside weather...');
-    request('http://nodemcu.jiihon.com/inne', function(err, res, body) {
+    request('http://inne.jiihon.com/inne', function(err, res, body) {
       try {
         inside = JSON.parse(body);
 
         message = 'Temperatur: ' + Number(inside['temperature']).toFixed(1).replace('.',',') + ' \xB0C\n';
         message += 'Luftfuktighet: '  + Number(inside['humidity']).toFixed(0).replace('.', ',') + ' RH%\n';
         message += 'Ljust: '
-        if(inside['brightness-raw']<=17) {
+        if(inside['lights-on']==0) {
           message += 'nej'; }
         else {
           message += 'ja' }


### PR DESCRIPTION
As it is now, the brightness-raw values have changed to a new reference, and as a result the bot says that it is dark even when the lights are on. Therefore I added a lights-on value in the API, and suggest that is used in the future.
